### PR TITLE
Added conversions to metabase data types

### DIFF
--- a/modules/drivers/ocient/src/metabase/driver/ocient.clj
+++ b/modules/drivers/ocient/src/metabase/driver/ocient.clj
@@ -87,25 +87,36 @@
 ;; e.g. VARCHAR(255) or NUMERIDECIMAL(16,4)
 (def ^:private database-type->base-type
   (sql-jdbc.sync/pattern-based-database-type->base-type
-   [[#"BIGINT"    :type/BigInteger]
+   [[#"ARRAY"     :type/Array]
+    [#"TUPLE"     :type/Array]
+    [#"VARBINARY" :type/*]
+    [#"BINARY"    :type/*]
+    [#"HASH"      :type/*]
+    [#"BYTE"      :type/*]
+    [#"POINT"     :type/*]
+    [#"LINESTRING":type/*]
+    [#"POLYGON"   :type/*]
+    [#"BIGINT"    :type/BigInteger]
+    [#"SMALLINT"  :type/Integer]
+    [#"TINYINT"   :type/Integer]
     [#"INT"       :type/Integer]
     [#"SHORT"     :type/Integer]
-    [#"SMALLINT"  :type/Integer]
-    [#"CHAR"      :type/Text]
     [#"VARCHAR"   :type/Text]
-    [#"TEXT"      :type/Text]
-    [#"BLOB"      :type/*]
-    [#"BINARY"    :type/*]
+    [#"CHAR"      :type/Text]
     [#"REAL"      :type/Float]
     [#"DOUBLE"    :type/Float]
     [#"FLOAT"     :type/Float]
+    [#"SINGLE PRECISION" :type/Float]
     [#"LONG"      :type/BigInteger]
     [#"DECIMAL"   :type/Decimal]
     [#"BOOLEAN"   :type/Boolean]
     [#"TIMESTAMP" :type/DateTime]
     [#"DATETIME"  :type/DateTime]
     [#"DATE"      :type/Date]
-    [#"TIME"      :type/Time]]))
+    [#"TIME"      :type/Time]
+    [#"IPV4"      :type/IPAddress]
+    [#"IP"        :type/IPAddress]
+    [#"UUID"      :type/UUID]]))
 
 (defmethod sql-jdbc.sync/database-type->base-type :ocient
   [_ database-type]

--- a/test/metabase/driver/ocient_test.clj
+++ b/test/metabase/driver/ocient_test.clj
@@ -52,7 +52,7 @@
                       (execute/execute-sql! :ocient :db dbdef (format "CREATE TABLE \"metabase\".\"%s\"
                                                                       (id INT NOT NULL, field_array INT[] NULL, field_tuple TUPLE<<INT, BIGINT>> NULL, field_varbinary varbinary(10) NULL, field_binary binary(4) NULL, field_hash hash(3) NULL, field_byte BYTE NULL, field_point POINT NULL, field_stpoint ST_POINT NULL, field_linestring LINESTRING NULL, field_stlinestring ST_LINESTRING NULL, field_polygon POLYGON NULL, field_stpolygon ST_POLYGON NULL, field_bigint BIGINT NULL, field_smallint SMALLINT NULL, field_tinyint TINYINT NULL, field_int INT NULL, field_varchar VARCHAR(255) NULL, field_character CHARACTER(10) NULL, field_char CHAR(10) NULL, field_real REAL NULL, field_double DOUBLE NULL, field_double_precision DOUBLE PRECISION NULL, field_float FLOAT NULL, field_single_precision SINGLE PRECISION NULL, field_decimal DECIMAL(5,2) NULL, field_boolean BOOLEAN NULL, field_timestamp TIMESTAMP NULL, field_datetime DATETIME NULL, field_date DATE NULL, field_time TIME NULL, field_ipv4 IPV4 NULL, field_ip IP NULL, field_uuid UUID NULL,
                                                                       CLUSTERING INDEX idx01 (id))
-                                                                      AS SELECT 0, int[](), tuple<<int,bigint>>(10, 9876543210), 'aabbccddeeff', '01234567', 'abcdef', 127, 'POINT(-87.6410 41.8841)', 'POINT(47.6410 11.8011)', 'LINESTRING(0 0,2 0)', 'LINESTRING(0 0,3 0)', 'POLYGON((0 0,2 0,5 5,0 2,0 0), (0 0,1 0,2 2,0 2,0 0))', 'POLYGON((0 0,1 0,5 5,0 1,0 0), (0 0,1 0,10 10,0 1,0 0))', 9876543210, 32767, 127, 123456789, 'porcupine', 'tree', 'apple', 2.718, 2.719, 2.720, 2.721, 2.722, 123.45, 'true', '2000:01:02T12:34:45', '2001:01:02T12:34:45', '2020-02-02', '12:34:56.012345678', '127.0.0.1', '0123:4567:89ab:cdef:0123:4567:89ab:cdef', '01234567-89ab-cdef-1357-0123456789ab' 
+                                                                      AS SELECT 0, int[](), tuple<<int,bigint>>(10, 9876543210), 'aabbccddeeff', '01234567', 'abcdef', 127, 'POINT(-87.6410 41.8841)', 'POINT(47.6410 11.8011)', 'LINESTRING(0 0,2 0)', 'LINESTRING(0 0,3 0)', 'POLYGON((0 0,2 0,5 5,0 2,0 0), (0 0,1 0,2 2,0 2,0 0))', 'POLYGON((0 0,1 0,5 5,0 1,0 0), (0 0,1 0,10 10,0 1,0 0))', 9876543210, 32767, 127, 123456789, 'porcupine', 'tree', 'apple', 2.718, 2.719, 2.720, 2.721, 2.722, 123.45, 'true', '2000:01:02T12:34:45', '2001:01:02T12:34:45', '2020-02-02', '12:34:56.012345678', '127.0.0.1', '0123:4567:89ab:cdef:0123:4567:89ab:cdef', '01234567-89ab-cdef-1357-0123456789ab'
                                                                       LIMIT 0"
                                                                       tablename))
 
@@ -61,7 +61,7 @@
                         (mt/with-temp Database [database {:engine :ocient, :details (assoc details :dbname dbname)}]
                           (mt/with-db database
                             (sync/sync-database! (mt/db))
-                          
+
                             (is (= [{:name "field_array",             :base_type :type/Array}
                                     {:name "field_bigint",            :base_type :type/BigInteger}
                                     {:name "field_binary",            :base_type :type/*}
@@ -100,6 +100,6 @@
                                     (partial into {})
                                     (db/select [Field :name :base_type] :table_id (mt/id (keyword tablename)) {:order-by [:name]})))))))
 
-                      ;; Clean up 
+                      ;; Clean up
                       (execute/execute-sql! :ocient :db dbdef (format "DROP TABLE IF EXISTS \"metabase\".\"%s\"" tablename))
                       (execute/execute-sql! :ocient :server dbdef (format "DROP DATABASE IF EXISTS \"%s\"" dbname))))))

--- a/test/metabase/driver/ocient_test.clj
+++ b/test/metabase/driver/ocient_test.clj
@@ -1,9 +1,15 @@
 (ns metabase.driver.ocient-test
   (:require [clojure.test :refer :all]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+            [metabase.models.database :refer [Database]]
+            [metabase.models.field :refer [Field]]
+            [metabase.sync :as sync]
             [metabase.test :as mt]
+            [metabase.test.data.interface :as tx]
             [metabase.test.data.sql.ddl :as ddl]
-            [metabase.util.honeysql-extensions :as hx]))
+            [metabase.test.data.sql-jdbc.execute :as execute]
+            [metabase.util.honeysql-extensions :as hx]
+            [toucan.db :as db]))
 
 (deftest additional-connection-string-options-test
   (mt/test-driver :ocient
@@ -32,3 +38,68 @@
                            (ddl/insert-rows-ddl-statements :ocient (hx/identifier :table "my_db" "my_table") [{:col1 "A", :col2 1}
                                                                                                               {:col1 "B", :col2 2}
                                                                                                               {:col1 "C", :col2 3}]))))))
+
+(deftest datatype-conversion-test
+  (mt/test-driver :ocient
+                  (testing "Make sure we convert all the Ocient DB types to Metabase base types correctly"
+                    (let [dbname (apply str "tst" (repeatedly 20 #(rand-nth (map char (range (int \a) (inc (int \z)))))))
+                          dbdef {:database-name dbname}
+                          tablename "data_conversion_test"]
+
+                      ;; Setup the DB
+                      (execute/execute-sql! :ocient :server dbdef (format "DROP DATABASE IF EXISTS \"%s\"" dbname))
+                      (execute/execute-sql! :ocient :server dbdef (format "CREATE DATABASE \"%s\"" dbname))
+                      (execute/execute-sql! :ocient :db dbdef (format "CREATE TABLE \"metabase\".\"%s\"
+                                                                      (id INT NOT NULL, field_array INT[] NULL, field_tuple TUPLE<<INT, BIGINT>> NULL, field_varbinary varbinary(10) NULL, field_binary binary(4) NULL, field_hash hash(3) NULL, field_byte BYTE NULL, field_point POINT NULL, field_stpoint ST_POINT NULL, field_linestring LINESTRING NULL, field_stlinestring ST_LINESTRING NULL, field_polygon POLYGON NULL, field_stpolygon ST_POLYGON NULL, field_bigint BIGINT NULL, field_smallint SMALLINT NULL, field_tinyint TINYINT NULL, field_int INT NULL, field_varchar VARCHAR(255) NULL, field_character CHARACTER(10) NULL, field_char CHAR(10) NULL, field_real REAL NULL, field_double DOUBLE NULL, field_double_precision DOUBLE PRECISION NULL, field_float FLOAT NULL, field_single_precision SINGLE PRECISION NULL, field_decimal DECIMAL(5,2) NULL, field_boolean BOOLEAN NULL, field_timestamp TIMESTAMP NULL, field_datetime DATETIME NULL, field_date DATE NULL, field_time TIME NULL, field_ipv4 IPV4 NULL, field_ip IP NULL, field_uuid UUID NULL,
+                                                                      CLUSTERING INDEX idx01 (id))
+                                                                      AS SELECT 0, int[](), tuple<<int,bigint>>(10, 9876543210), 'aabbccddeeff', '01234567', 'abcdef', 127, 'POINT(-87.6410 41.8841)', 'POINT(47.6410 11.8011)', 'LINESTRING(0 0,2 0)', 'LINESTRING(0 0,3 0)', 'POLYGON((0 0,2 0,5 5,0 2,0 0), (0 0,1 0,2 2,0 2,0 0))', 'POLYGON((0 0,1 0,5 5,0 1,0 0), (0 0,1 0,10 10,0 1,0 0))', 9876543210, 32767, 127, 123456789, 'porcupine', 'tree', 'apple', 2.718, 2.719, 2.720, 2.721, 2.722, 123.45, 'true', '2000:01:02T12:34:45', '2001:01:02T12:34:45', '2020-02-02', '12:34:56.012345678', '127.0.0.1', '0123:4567:89ab:cdef:0123:4567:89ab:cdef', '01234567-89ab-cdef-1357-0123456789ab' 
+                                                                      LIMIT 0"
+                                                                      tablename))
+
+                      ;; Sync the DB and make sure columns converted to the correct base type
+                      (let [details (tx/dbdef->connection-details :ocient :db {:database-name dbname})]
+                        (mt/with-temp Database [database {:engine :ocient, :details (assoc details :dbname dbname)}]
+                          (mt/with-db database
+                            (sync/sync-database! (mt/db))
+                          
+                            (is (= [{:name "field_array",             :base_type :type/Array}
+                                    {:name "field_bigint",            :base_type :type/BigInteger}
+                                    {:name "field_binary",            :base_type :type/*}
+                                    {:name "field_boolean",           :base_type :type/Boolean}
+                                    {:name "field_byte",              :base_type :type/*}
+                                    {:name "field_char",              :base_type :type/Text}
+                                    {:name "field_character",         :base_type :type/Text}
+                                    {:name "field_date",              :base_type :type/Date}
+                                    {:name "field_datetime",          :base_type :type/DateTime}
+                                    {:name "field_decimal",           :base_type :type/Decimal}
+                                    {:name "field_double",            :base_type :type/Float}
+                                    {:name "field_double_precision",  :base_type :type/Float}
+                                    {:name "field_float",             :base_type :type/Float}
+                                    {:name "field_hash",              :base_type :type/*}
+                                    {:name "field_int",               :base_type :type/Integer}
+                                    {:name "field_ip",                :base_type :type/IPAddress}
+                                    {:name "field_ipv4",              :base_type :type/IPAddress}
+                                    {:name "field_linestring",        :base_type :type/*}
+                                    {:name "field_point",             :base_type :type/*}
+                                    {:name "field_polygon",           :base_type :type/*}
+                                    {:name "field_real",              :base_type :type/Float}
+                                    {:name "field_single_precision",  :base_type :type/Float}
+                                    {:name "field_smallint",          :base_type :type/Integer}
+                                    {:name "field_stlinestring",      :base_type :type/*}
+                                    {:name "field_stpoint",           :base_type :type/*}
+                                    {:name "field_stpolygon",         :base_type :type/*}
+                                    {:name "field_time",              :base_type :type/Time}
+                                    {:name "field_timestamp",         :base_type :type/DateTime}
+                                    {:name "field_tinyint",           :base_type :type/*}
+                                    {:name "field_tuple",             :base_type :type/Array}
+                                    {:name "field_uuid",              :base_type :type/UUID}
+                                    {:name "field_varbinary",         :base_type :type/*}
+                                    {:name "field_varchar",           :base_type :type/Text}
+                                    {:name "id",                      :base_type :type/Integer}]
+                                  (map
+                                    (partial into {})
+                                    (db/select [Field :name :base_type] :table_id (mt/id (keyword tablename)) {:order-by [:name]})))))))
+
+                      ;; Clean up 
+                      (execute/execute-sql! :ocient :db dbdef (format "DROP TABLE IF EXISTS \"metabase\".\"%s\"" tablename))
+                      (execute/execute-sql! :ocient :server dbdef (format "DROP DATABASE IF EXISTS \"%s\"" dbname))))))


### PR DESCRIPTION
Updated the conversion list of Ocient data types to Metabase datatypes

Added
- Array
- Tuple
- Varbinary
- Hash
- Byte
- Point
- Linestring
- Polygon
- Tinyint
- IPV4
- IP
- UUID

Removed the following captures, as they are not listed Ocient data types
- Text
- Blob
Lastly, added a unit test which verifies these conversions are done correctly